### PR TITLE
Add a label to pganssle's post link on deprecating `setup.py`

### DIFF
--- a/source/discussions/setup-py-deprecated.rst
+++ b/source/discussions/setup-py-deprecated.rst
@@ -210,6 +210,6 @@ has now been reduced to the role of a build backend.
 Where to read more about this?
 ==============================
 
-* https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
+* `Why you shouldn't invoke setup.py directly by Paul Ganssle <https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html>`__
 
 * :doc:`setuptools:deprecated/commands`


### PR DESCRIPTION
I noticed it as it ended up in the translation strings.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1.org.readthedocs.build/en/1/

<!-- readthedocs-preview python-packaging-user-guide end -->